### PR TITLE
Automatically run `gulp` with dev Rails server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ http://foundation.zurb.com/apps
 `rake zfapp:install`
 
 * run Gulp from the root directory to build the necessary javascript files, partials, templates, and iconic images.  This will also watch for template changes.
+* Note: Gulp will automatically run while a development Rails server is running. This was set up in
+  config/initializers/gulp.rb
 
 <tt>gulp</tt>
 

--- a/config/initializers/gulp.rb
+++ b/config/initializers/gulp.rb
@@ -1,0 +1,10 @@
+# Run gulp automatically for dev servers
+
+if defined?(Rails::Server) && Rails.env.development?
+  pid = fork { exec('gulp') }
+
+  at_exit do
+    Process.kill('INT', pid)
+    Process.waitpid(pid)
+  end
+end


### PR DESCRIPTION
So that I don't have to run `gulp` separately while developing.
